### PR TITLE
Suggestion to add first specs

### DIFF
--- a/spec/support/dummy/dummy.rb
+++ b/spec/support/dummy/dummy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DummyA
+  def dummy
+    p "It's a dummy method"
+  end
+end
+
+class DummyB
+  def dummy
+    DummyA.new.dummy
+  end
+end

--- a/spec/trace_location_spec.rb
+++ b/spec/trace_location_spec.rb
@@ -1,7 +1,84 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+require_relative 'support/dummy/dummy'
+
 RSpec.describe TraceLocation do
   it 'has a version number' do
     expect(TraceLocation::VERSION).not_to be nil
+  end
+
+  describe '.trace' do
+    before do
+      TraceLocation.config.dest_dir = 'spec/support/logs'
+    end
+
+    context 'when a method is ca' do
+      dummy_instance = DummyA.new
+
+      let(:log_file) { Dir.entries('spec/support/logs/').select { |file_name| file_name.match?(/\.md/) }.last }
+      let(:content) { File.read File.join('spec', 'support', 'logs', log_file) }
+
+      before do
+        TraceLocation.trace { dummy_instance.dummy }
+      end
+
+      it 'including correct path' do
+        path, lineno = dummy_instance.method(:dummy).source_location
+        path = path.delete_prefix "#{Dir.pwd}/"
+
+        expect(content).to include "#{path}:#{lineno}"
+      end
+
+      it 'including method name' do
+        name = dummy_instance.method(:dummy).name
+
+        expect(content).to include "def #{name}"
+      end
+    end
+
+    context 'when the method is called depending on other' do
+      dummy_instance_a = DummyA.new
+      dummy_instance_b = DummyB.new
+
+      let(:log_file) { Dir.entries('spec/support/logs/').select { |file_name| file_name.match?(/\.md/) }.last }
+      let(:content) { File.read File.join('spec', 'support', 'logs', log_file) }
+
+      before do
+        TraceLocation.trace { dummy_instance_b.dummy }
+      end
+
+      it 'including path of DummyA.dummy' do
+        path, lineno = dummy_instance_b.method(:dummy).source_location
+        path = path.delete_prefix "#{Dir.pwd}/"
+
+        expect(content).to include "#{path}:#{lineno}"
+      end
+
+      it 'including path of DummyB.dummy' do
+        path, lineno = dummy_instance_b.method(:dummy).source_location
+        path = path.delete_prefix "#{Dir.pwd}/"
+
+        expect(content).to include "#{path}:#{lineno}"
+      end
+
+      it 'including method name of DummyA.dummy' do
+        name = dummy_instance_a.method(:dummy).name
+
+        expect(content).to include "def #{name}"
+      end
+
+      it 'including method name of DummyB.dummy' do
+        name = dummy_instance_b.method(:dummy).name
+
+        expect(content).to include "def #{name}"
+      end
+    end
+
+    after do
+      Dir.foreach('spec/support/logs') do |file_name|
+        FileUtils.rm File.join('spec', 'support', 'logs', file_name), force: true
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a suggestion to add first specs for this gem,
because TraceLocation has no specs yet.
Although there is still no verification for trace method options
(e.g. ignore, format). It might be added by other contexts.
Would you tell me how do you think about this?
Or if you have some better ways, please let me know.