### PR TITLE
Fix README.md for options 'match' & 'ignore'

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Then you can get logs like this: [.md](https://github.com/yhirano55/trace_locati
 | name | content | example |
 |:-----|:--------|:--------|
 | format | `:markdown`, `:log`, `:csv` (default: `:markdown`) | `:markdown` |
-| match | Regexp for allow list | `/activerecord/` |
-| ignore | Regexp for deny list | `/bootsnap\|activesupport/` |
+| match | Regexp, Symbol, String for allow list | `:activerecord` |
+| ignore | Regexp, Symbol, String for deny list | `/bootsnap\|activesupport/ |
 
 ## More examples
 


### PR DESCRIPTION
In README.md, it seems that only regexp is accept for allow & deny list,
but actually these options also allow Symbol and String.
And it specified in lib/trace_location/collector.rb:19 & 20

```ruby
          next if match && !trace_point.path.to_s.match?(/#{match}/)
          next if ignore && trace_point.path.to_s.match?(/#{ignore}/)
```

Here.
```ruby
/#{match}/
/#{ignore}/
```