### PR TITLE
Options 'match' & 'ignore' accept array as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Then you can get logs like this: [.md](https://github.com/yhirano55/trace_locati
 | name | content | example |
 |:-----|:--------|:--------|
 | format | `:markdown`, `:log`, `:csv` (default: `:markdown`) | `:markdown` |
-| match | Regexp, Symbol, String for allow list | `:activerecord` |
-| ignore | Regexp, Symbol, String for deny list | `/bootsnap\|activesupport/ |
+| match | Regexp, Symbol, String or Array for allow list | `[:activerecord, :activesupport]` |
+| ignore | Regexp, Symbol, String or Array for deny list | `/bootsnap\|activesupport/` |
 
 ## More examples
 

--- a/lib/trace_location/collector.rb
+++ b/lib/trace_location/collector.rb
@@ -16,8 +16,8 @@ module TraceLocation
         cache = {}
 
         tracer = TracePoint.new(:call, :return) do |trace_point|
-          next if match && !trace_point.path.to_s.match?(/#{match}/)
-          next if ignore && trace_point.path.to_s.match?(/#{ignore}/)
+          next if match && !trace_point.path.to_s.match?(/#{Array(match).join('|')}/)
+          next if ignore && trace_point.path.to_s.match?(/#{Array(ignore).join('|')}/)
 
           id += 1
           caller_path, caller_lineno = trace_point.binding.of_caller(2).source_location

--- a/spec/support/dummy/dependence_on_multiple_class.rb
+++ b/spec/support/dummy/dependence_on_multiple_class.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DependenceOnMultipleClass
+  def self.dependent_method
+    DependenceOnOtherClass.dependent_method
+  end
+end


### PR DESCRIPTION
Trace methods option 'match' & 'ignore' can accept multiple arguments
only by Regexp in current.
But it seems that Array is more familiar and developer-friendly.
This PR is for that and I'd like you to tell me your opinion. @yhirano55