### PR TITLE
Add abbr format for markdown

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Metrics:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Then you can get logs like this: [.md](https://github.com/yhirano55/trace_locati
 
 | name | content | example |
 |:-----|:--------|:--------|
-| format | `:markdown`, `:log`, `:csv` (default: `:markdown`) | `:markdown` |
+| format | `:md`, `:log`, `:csv` (default: `:md`) | `:md` |
 | match | Regexp, Symbol, String or Array for allow list | `[:activerecord, :activesupport]` |
 | ignore | Regexp, Symbol, String or Array for deny list | `/bootsnap\|activesupport/` |
 
@@ -69,7 +69,7 @@ Results: [.md](https://github.com/yhirano55/trace_location/blob/master/examples/
 ```ruby
 class User < ApplicationRecord
   # temporary surrounding with TraceLocation#trace
-  TraceLocation.trace(format: :markdown, ignore: /activesupport/) do
+  TraceLocation.trace(format: :md, ignore: /activesupport/) do
     has_secure_password
   end
 ```
@@ -87,7 +87,7 @@ class BooksController < ApplicationController
     @books = Book.all
 
     # temporary surrounding with TraceLocation#trace
-    TraceLocation.trace(format: :markdown, ignore: /activesupport|rbenv|concurrent-ruby/) do
+    TraceLocation.trace(format: :md, ignore: /activesupport|rbenv|concurrent-ruby/) do
       render json: @books
     end
   end

--- a/lib/trace_location/config.rb
+++ b/lib/trace_location/config.rb
@@ -7,7 +7,7 @@ module TraceLocation
     def initialize
       @current_dir = Dir.pwd
       @dest_dir = Dir.pwd
-      @default_format = :markdown
+      @default_format = :md
     end
   end
 end

--- a/lib/trace_location/report.rb
+++ b/lib/trace_location/report.rb
@@ -9,6 +9,7 @@ module TraceLocation
     GENERATORS = {
       csv: ::TraceLocation::Generator::Csv,
       log: ::TraceLocation::Generator::Log,
+      md: ::TraceLocation::Generator::Markdown,
       markdown: ::TraceLocation::Generator::Markdown
     }.freeze
 

--- a/spec/trace_location_spec.rb
+++ b/spec/trace_location_spec.rb
@@ -276,6 +276,29 @@ RSpec.describe TraceLocation do
         end
       end
 
+      context 'with "md"' do
+        let(:log_file) { Dir.entries('spec/support/logs/').select { |file_name| file_name.match?(/\.md/) }.last }
+        let(:content) { File.read File.join('spec', 'support', 'logs', log_file) }
+        let(:method) { Independence.method(:independent_method) }
+
+        before do
+          TraceLocation.trace(format: :md) { method.call }
+        end
+
+        it 'including correct path' do
+          path, lineno = method.source_location
+          path = path.delete_prefix "#{Dir.pwd}/"
+
+          expect(content).to include "#{path}:#{lineno}"
+        end
+
+        it 'including method name' do
+          method_name = method.name
+
+          expect(content).to include "def self.#{method_name}"
+        end
+      end
+
       context 'with "log"' do
         let(:log_file) { Dir.entries('spec/support/logs/').select { |file_name| file_name.match?(/\.log/) }.last }
         let(:content) { File.read File.join('spec', 'support', 'logs', log_file) }


### PR DESCRIPTION
I felt It's better to be same as file extension for each formats. So I've added `md` format for markdown.