### PR TITLE
Fix an error that occurs when using the `pp` method

### DIFF
--- a/lib/trace_location/collector.rb
+++ b/lib/trace_location/collector.rb
@@ -24,6 +24,7 @@ module TraceLocation
           location_cache_key = "#{caller_path}:#{caller_lineno}"
 
           mes = extract_method_from(trace_point)
+          next if mes.source_location[0] == '<internal:prelude>'
 
           case trace_point.event
           when :call

--- a/spec/trace_location_spec.rb
+++ b/spec/trace_location_spec.rb
@@ -351,6 +351,12 @@ RSpec.describe TraceLocation do
       end
     end
 
+    it 'passing a block including the `pp` method' do
+      expect {
+        TraceLocation.trace { pp 'foo' }
+      }.to output(/foo/).to_stdout
+    end
+
     after do
       Dir.foreach('spec/support/logs') do |file_name|
         FileUtils.rm File.join('spec', 'support', 'logs', file_name), force: true


### PR DESCRIPTION
If you pass a block including the `pp` method, the following error occurs:

```ruby
TraceLocation.trace { pp 'foo' }
# Failure: Could not load source for : No such file or directory @ rb_sysopen - <internal:prelude>
#=> false
```

The cause of this error is that the `pp` method definition cannot be obtained with `source_location`.

```ruby
method(:pp).source_location
#=> ["<internal:prelude>", 214]
```