### PR TITLE
Fix failing specs on Ruby 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,9 @@ language: ruby
 cache: bundler
 rvm:
   - 2.6.3
+  - ruby-head
 before_install: gem install bundler -v 2.0.1
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head

--- a/spec/trace_location_spec.rb
+++ b/spec/trace_location_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe TraceLocation do
         end
 
         it 'including method calling' do
-          method_calling = method.to_s.gsub(/#<Method: |>/, '')
+          method_calling = "#{method.receiver}.#{method.name}"
 
           expect(content).to include "[#{method_calling}]"
         end
@@ -344,7 +344,7 @@ RSpec.describe TraceLocation do
         end
 
         it 'including method calling' do
-          method_calling = method.to_s.gsub(/#<Method: |>/, '')
+          method_calling = "#{method.receiver}.#{method.name}"
 
           expect(content).to include method_calling.to_s
         end


### PR DESCRIPTION
The spec failed due to the change in Method#inspect format in Ruby 2.7.0.
refs: https://github.com/ruby/ruby/commit/47b04557b01dc109ccafc33db8e80148f07457a9

This pull request fixes a problem and adds ruby-head so that you can see it in TravisCI.