### PR TITLE
Display Exception#full_message when an error occurred in the traced block

### DIFF
--- a/lib/trace_location.rb
+++ b/lib/trace_location.rb
@@ -21,7 +21,8 @@ module TraceLocation # :nodoc:
     Report.build(result.events, result.return_value, options).generate
     true
   rescue StandardError => e
-    $stderr.puts "Failure: #{e.message}"
+    $stderr.puts "Failure: TraceLocation got an unexpected error."
+    $stderr.puts e.full_message
     false
   end
 


### PR DESCRIPTION
# Problem


TraceLocation displays the error message when an error occurred in the traced block, but I think it is not enough for debugging.
I think backtrace is important to debug, but it omits backtrace.


```ruby
require 'trace_location'

TraceLocation.trace(format: :log) do
  raise 'error'
end
```

```bash
$ ruby test.rb
Failure: error
```

Yes, in this example, we can easily find the cause of the error. But actually we'd like to use this gem for a large code base, so the error message without backtraces is not helpful.


# Solution


Display `Exception#full_message` instead.
https://docs.ruby-lang.org/en/2.6.0/Exception.html#method-i-full_message



This method returns a string with the exception message and backtraces. It is the same format of raised exceptions.



The above example will display the following output with this pull request:


```bash
$ ruby test.rb
Failure: TraceLocation got an unexpected error.
test.rb:4:in `block in <main>': error (RuntimeError)
  from /path/to/trace_location-0.9.6/lib/trace_location/collector.rb:66:in `block in collect'
  from <internal:trace_point>:196:in `enable'
  from /path/to/trace_location-0.9.6/lib/trace_location/collector.rb:66:in `collect'
  from /path/to/trace_location-0.9.6/lib/trace_location.rb:20:in `trace'
  from test.rb:3:in `<main>'
```


Note: 
`Exception#full_message` has been available since Ruby 2.5 but the `required_ruby_version` is `>= 2.6.0`, so we can use the method for this gem.