### PR TITLE
Fix error on not-indented method definition

### DIFF
--- a/lib/trace_location/collector.rb
+++ b/lib/trace_location/collector.rb
@@ -82,7 +82,7 @@ module TraceLocation
       end
 
       def remove_indent(source)
-        indent = source.split("\n").first.match(/\A(\s+).+\z/)[1]
+        indent = source.split("\n").first.match(/\A(\s*).+\z/)[1]
         source.split("\n").map { |line| line.gsub(/\A#{indent}/, '') }.join("\n")
       end
     end


### PR DESCRIPTION
`TraceLocation.trace` prints an error when the traced block calls a method that is defined without indentations.


```ruby
def foo
end

require 'trace_location'

TraceLocation.trace do
  foo
end
```

```bash
$ ruby test.rb
Failure: undefined method `[]' for nil:NilClass
```


For more information, with #22 

```bash

$ ruby test.rb
Failure: TraceLocation got an unexpected error.
/path/to/trace_location-0.9.6/lib/trace_location/collector.rb:85:in `remove_indent': undefined method `[]' for nil:NilClass (NoMethodError)
	from /path/to/trace_location-0.9.6/lib/trace_location/collector.rb:60:in `block in collect'
	from test.rb:1:in `foo'
	from test.rb:7:in `block in <main>'
	from /path/to/trace_location-0.9.6/lib/trace_location/collector.rb:66:in `block in collect'
	from <internal:trace_point>:196:in `enable'
	from /path/to/trace_location-0.9.6/lib/trace_location/collector.rb:66:in `collect'
	from /path/to/trace_location-0.9.6/lib/trace_location.rb:20:in `trace'
	from test.rb:6:in `<main>'
```


This pull request fixes this problem.