### PR TITLE
Make it faster🚀

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,16 +2,12 @@ PATH
   remote: .
   specs:
     trace_location (0.9.6)
-      binding_of_caller
       method_source
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
-    debug_inspector (0.0.3)
     diff-lcs (1.3)
     jaro_winkler (1.5.2)
     method_source (0.9.2)

--- a/lib/trace_location/collector.rb
+++ b/lib/trace_location/collector.rb
@@ -13,6 +13,7 @@ module TraceLocation
         hierarchy = 0
         id = 0
         cache = {}
+        method_source_cache = {}
 
         tracer = TracePoint.new(:call, :return) do |trace_point|
           next if match && !trace_point.path.to_s.match?(/#{Array(match).join('|')}/)
@@ -27,6 +28,8 @@ module TraceLocation
           mes = extract_method_from(trace_point)
           next if mes.source_location[0] == '<internal:prelude>'
 
+          method_source = method_source_cache[mes] ||= remove_indent(mes.source)
+
           case trace_point.event
           when :call
             cache[location_cache_key] = hierarchy
@@ -40,7 +43,7 @@ module TraceLocation
               caller_lineno: caller_lineno,
               owner: mes.owner,
               name: mes.name,
-              source: remove_indent(mes.source),
+              source: method_source,
               hierarchy: hierarchy,
               is_module: trace_point.self.is_a?(Module)
             )
@@ -58,7 +61,7 @@ module TraceLocation
               caller_lineno: caller_lineno,
               owner: mes.owner,
               name: mes.name,
-              source: remove_indent(mes.source),
+              source: method_source,
               hierarchy: hierarchy,
               is_module: trace_point.self.is_a?(Module)
             )

--- a/lib/trace_location/collector.rb
+++ b/lib/trace_location/collector.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'binding_of_caller'
 require 'method_source'
 
 module TraceLocation
@@ -20,7 +19,9 @@ module TraceLocation
           next if ignore && trace_point.path.to_s.match?(/#{Array(ignore).join('|')}/)
 
           id += 1
-          caller_path, caller_lineno = trace_point.binding.of_caller(2).source_location
+          caller_loc = caller_locations(2, 1)[0]
+          caller_path = caller_loc.absolute_path
+          caller_lineno = caller_loc.lineno
           location_cache_key = "#{caller_path}:#{caller_lineno}"
 
           mes = extract_method_from(trace_point)

--- a/lib/trace_location/collector.rb
+++ b/lib/trace_location/collector.rb
@@ -82,7 +82,7 @@ module TraceLocation
       end
 
       def remove_indent(source)
-        indent = source.split("\n").first.match(/\A(\s+).+\z/)[1]
+        indent = source.split("\n").first.match(/\A(\s*).+\z/)[1]
         source.split("\n").map { |line| line.gsub(/\A#{indent}/, '') }.join("\n")
       end
     end

--- a/lib/trace_location/collector.rb
+++ b/lib/trace_location/collector.rb
@@ -83,8 +83,8 @@ module TraceLocation
       end
 
       def remove_indent(source)
-        indent = source.split("\n").first.match(/\A(\s*).+\z/)[1]
-        source.split("\n").map { |line| line.gsub(/\A#{indent}/, '') }.join("\n")
+        indent = source[/\A(\s*)/, 1]
+        source.gsub(/^#{indent}/, '')
       end
     end
   end

--- a/trace_location.gemspec
+++ b/trace_location.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.6.0'
 
-  s.add_dependency 'binding_of_caller'
   s.add_dependency 'method_source'
 
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
This pull request improves performance.

I've confirmed it was about 6x faster in a micro benchmark and a real rails application.


# Benchmark scripts


## Micro benchmark

```ruby
$LOAD_PATH << './lib'

require 'benchmark'
require 'trace_location'

def noop
end

def heavy
  100000.times {noop}
end

Benchmark.bmbm do |x|
  x.report{1.times{TraceLocation.trace{heavy}}}
end
```


## With rails application


```ruby
# Execute it with rails runner

require 'benchmark'
require 'trace_location'

User.first # because the first execution is really slow

Benchmark.bmbm do |x|
  x.report{1.times{TraceLocation.trace{User.first}}}
end
```



# Benchmark results


## Micro benchmark



### first - 3462bd71c85a1496938c37ca54406464945da5a4

```
Rehearsal ------------------------------------
 Created at /home/pocke/ghq/github.com/yhirano55/trace_location/trace_location-2020062014061592631234.md
 13.271392   0.083000  13.354392 ( 13.374203)
-------------------------- total: 13.354392sec

       user     system      total        real
 Created at /home/pocke/ghq/github.com/yhirano55/trace_location/trace_location-2020062014061592631249.md
 14.247306   0.053228  14.300534 ( 14.321461)
```


### Do not use binding_of_caller - 7cf5769791c054495ec406c3829c358f4b6951f2

```
Rehearsal ------------------------------------
 Created at /home/pocke/ghq/github.com/yhirano55/trace_location/trace_location-2020062014061592632386.md
  9.050748   0.062487   9.113235 (  9.126239)
--------------------------- total: 9.113235sec

       user     system      total        real
 Created at /home/pocke/ghq/github.com/yhirano55/trace_location/trace_location-2020062014061592632395.md
  9.554962   0.046541   9.601503 (  9.615075)
```

### Simplify remove_indent - febf7b001575c6275ae9e179e69c916db964b0fc

```
Rehearsal ------------------------------------
 Created at /home/pocke/ghq/github.com/yhirano55/trace_location/trace_location-2020062015061592633000.md
  8.375018   0.087021   8.462039 (  8.473832)
--------------------------- total: 8.462039sec

       user     system      total        real
 Created at /home/pocke/ghq/github.com/yhirano55/trace_location/trace_location-2020062015061592633009.md
  8.795492   0.033288   8.828780 (  8.841047)
```


### Cache method source - 900202c87e03a2360e53fd67f29e133b432d4de6

```
Rehearsal ------------------------------------
 Created at /home/pocke/ghq/github.com/yhirano55/trace_location/trace_location-2020062015061592634643.md
  2.478327   0.013296   2.491623 (  2.494657)
--------------------------- total: 2.491623sec

       user     system      total        real
 Created at /home/pocke/ghq/github.com/yhirano55/trace_location/trace_location-2020062015061592634646.md
  2.325903   0.016581   2.342484 (  2.345369)
```


## With rails application

I only execute the benchmark with the base commit and the latest commit for Rails app.

### first - 3462bd71c85a1496938c37ca54406464945da5a4


```
Rehearsal ------------------------------------
 Created at /home/pocke/ghq/github.com/bitjourney/kibela/log/trace_location-2020062015061592635193.md
  2.301371   0.023957   2.325328 (  2.329522)
--------------------------- total: 2.325328sec

       user     system      total        real
 Created at /home/pocke/ghq/github.com/bitjourney/kibela/log/trace_location-2020062015061592635195.md
  2.426445   0.000323   2.426768 (  2.430787)
```

### Cache method source - 900202c87e03a2360e53fd67f29e133b432d4de6

```
Rehearsal ------------------------------------
 Created at /home/pocke/ghq/github.com/bitjourney/kibela/log/trace_location-2020062015061592635466.md
  0.575040   0.016643   0.591683 (  0.593343)
--------------------------- total: 0.591683sec

       user     system      total        real
 Created at /home/pocke/ghq/github.com/bitjourney/kibela/log/trace_location-2020062015061592635467.md
  0.363144   0.000371   0.363515 (  0.364667)
```




# Note

This pull request contains #23 commit to avoid conflicting.
