### PR TITLE
Avoid tracing methods that are defined in the internal or eval

### DIFF
--- a/lib/trace_location/collector.rb
+++ b/lib/trace_location/collector.rb
@@ -26,7 +26,7 @@ module TraceLocation
           location_cache_key = "#{caller_path}:#{caller_lineno}"
 
           mes = extract_method_from(trace_point)
-          next if mes.source_location[0] == '<internal:prelude>'
+          next if mes.source_location[0].match?(/\A(?:<internal:.+>|\(eval\))\z/)
 
           method_source = method_source_cache[mes] ||= remove_indent(mes.source)
 

--- a/spec/trace_location_spec.rb
+++ b/spec/trace_location_spec.rb
@@ -357,6 +357,18 @@ RSpec.describe TraceLocation do
       }.to output(/foo/).to_stdout
     end
 
+    it 'passing a block incluing GC module method' do
+      expect {
+        TraceLocation.trace { GC.stat; puts 'success' }
+      }.to output(/success/).to_stdout
+    end
+
+    it 'passing a block incluing eval' do
+      expect {
+        TraceLocation.trace { eval 'def foo() pp "foo" end'; foo }
+      }.to output(/foo/).to_stdout
+    end
+
     after do
       Dir.foreach('spec/support/logs') do |file_name|
         FileUtils.rm File.join('spec', 'support', 'logs', file_name), force: true


### PR DESCRIPTION
This pull request avoids recording methods that are defined in the internal or `eval`.



TraceLocation displays an error if the block contains a method that defined in the internal or `eval`.
For example


```ruby
TraceLocation.trace do
  # GC module is defined in internal at least Ruby 2.7.
  GC.stat
end

eval <<~RUBY
  def foo
  end
RUBY

TraceLocation.trace do
  # foo is defined in eval
  foo
end
```


This pull request will fix this problem by skipping recording for them.