### PR TITLE
Feature Request: Add `trace_location` command to trace code from CLI conveniently

### DIFF
--- a/exe/trace_location
+++ b/exe/trace_location
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require 'trace_location'
+require 'trace_location/cli'
+
+TraceLocation::CLI.new(ARGV).run

--- a/lib/trace_location/cli.rb
+++ b/lib/trace_location/cli.rb
@@ -1,0 +1,59 @@
+require 'optparse'
+
+module TraceLocation
+  class CLI
+    attr_reader :argv
+
+    def initialize(argv)
+      @argv = argv
+    end
+
+    def run
+      opt = OptionParser.new
+      opt.on('-f FORMAT', '--format=FORMAT', 'Report format (default: :md)', &:to_sym)
+      opt.on('-m REGEXP', '--match=REGEXP') { |str| Regexp.new(str) }
+      opt.on('-i REGEXP', '--ignore=REGEXP') { |str| Regexp.new(str) }
+      opt.on('-d DIR', '--dest-dir=DIR')
+      opt.on('-e code')
+
+      params = {}
+      opt.order!(argv, into: params)
+      params.transform_keys! { |k| k.to_s.gsub('-', '_').to_sym }
+
+      if code = params.delete(:e)
+        exec_code code, params
+      else
+        file = argv.shift
+        unless file
+          puts opt.help
+          exit 1
+        end
+
+        exec_command file, params
+      end
+    end
+
+    private
+
+    def exec_command(cmd, params)
+      path =
+        if File.exist?(cmd)
+          cmd
+        else
+          `which #{cmd}`.chomp
+        end
+
+      $PROGRAM_NAME = cmd
+
+      TraceLocation.trace(params) do
+        load path
+      end
+    end
+
+    def exec_code(code, params)
+      TraceLocation.trace(params) do
+        eval code
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds a CLI tool of TraceLocation.

Usage:

```bash
# Trace some command written in Ruby
$ trace_location bundle -v

# Trace ruby file
$ echo "def foo() puts 'hello' end; foo" > test.rb
$ trace_location test.rb

# Trace ruby code
$ trace_location -e "def foo() puts 'hello' end; foo"

# Specify options
$ trace_location --ignore active_support --format log --dest-dir /tmp test.rb
```

I think it is useful to inspect a small Ruby code.


---


It is inspired by https://github.com/pocke/stackprof-run.