### PR TITLE
Add :methods option to filter by method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Then you can get logs like this: [.md](https://github.com/yhirano55/trace_locati
 | format | `:md`, `:log`, `:csv` (default: `:md`) | `:md` |
 | match | Regexp, Symbol, String or Array for allow list | `[:activerecord, :activesupport]` |
 | ignore | Regexp, Symbol, String or Array for deny list | `/bootsnap\|activesupport/` |
+| methods | Symbol or Array of method names | `[:call]` |
 
 ## More examples
 

--- a/lib/trace_location.rb
+++ b/lib/trace_location.rb
@@ -16,8 +16,9 @@ module TraceLocation # :nodoc:
   def self.trace(options = {}, &block)
     match = options.delete(:match)
     ignore = options.delete(:ignore)
+    methods = options.delete(:methods)
 
-    result = Collector.collect(match: match, ignore: ignore, &block)
+    result = Collector.collect(match: match, ignore: ignore, methods: methods, &block)
     Report.build(result.events, result.return_value, options).generate
     true
   rescue StandardError => e

--- a/lib/trace_location/collector.rb
+++ b/lib/trace_location/collector.rb
@@ -8,7 +8,8 @@ module TraceLocation
     Result = Struct.new(:events, :return_value)
 
     class << self
-      def collect(match:, ignore:, &block)
+      def collect(match:, ignore:, methods:, &block)
+        methods = Array(methods) if methods
         events = []
         hierarchy = 0
         id = 0
@@ -18,6 +19,7 @@ module TraceLocation
         tracer = TracePoint.new(:call, :return) do |trace_point|
           next if match && !trace_point.path.to_s.match?(/#{Array(match).join('|')}/)
           next if ignore && trace_point.path.to_s.match?(/#{Array(ignore).join('|')}/)
+          next if methods && !methods.include?(trace_point.method_id)
 
           id += 1
           caller_loc = caller_locations(2, 1)[0]

--- a/spec/trace_location_spec.rb
+++ b/spec/trace_location_spec.rb
@@ -163,6 +163,34 @@ RSpec.describe TraceLocation do
       end
     end
 
+    context 'with "methods"' do
+      let(:log_file) { Dir.entries('spec/support/logs/').select { |file_name| file_name.match?(/\.md/) }.last }
+      let(:content) { File.read File.join('spec', 'support', 'logs', log_file) }
+
+      context 'when argument is kind of Array' do
+        let(:method) { DependenceOnOtherClass.method(:dependent_method) }
+        let(:depended_method) { Independence.method(:independent_method) }
+
+        before do
+          TraceLocation.trace(methods: [:dependent_method]) { method.call }
+        end
+
+        it 'including path of target method' do
+          path, lineno = method.source_location
+          path = path.delete_prefix "#{Dir.pwd}/"
+
+          expect(content).to include "#{path}:#{lineno}"
+        end
+
+        it 'does not include non-specified methods' do
+          path, lineno = depended_method.source_location
+          path = path.delete_prefix "#{Dir.pwd}/"
+
+          expect(content).not_to include "#{path}:#{lineno}"
+        end
+      end
+    end
+
     context 'with "ignore"' do
       let(:log_file) { Dir.entries('spec/support/logs/').select { |file_name| file_name.match?(/\.md/) }.last }
       let(:content) { File.read File.join('spec', 'support', 'logs', log_file) }


### PR DESCRIPTION
There are some situations when filtering by method names could be useful. For example, looking at Rack middleware (`methods: [:call]`) or Active Record save/update flow (`methods: [:save]`).
