### PR TITLE
Handle method source not found exceptions

### DIFF
--- a/lib/trace_location/collector.rb
+++ b/lib/trace_location/collector.rb
@@ -30,7 +30,16 @@ module TraceLocation
           mes = extract_method_from(trace_point)
           next if mes.source_location[0].match?(/\A(?:<internal:.+>|\(eval\))\z/)
 
-          method_source = method_source_cache[mes] ||= remove_indent(mes.source)
+          method_source =
+            if method_source_cache.key?(mes)
+              method_source_cache[mes]
+            else
+              method_source_cache[mes] =
+                begin
+                  remove_indent(mes.source)
+                rescue MethodSource::SourceNotFoundError
+                end
+            end
 
           case trace_point.event
           when :call


### PR DESCRIPTION
Method source raises an exception (Rails 7.0) when tries to get source for methods defined in templates:

```
(eval):2: syntax error, unexpected '<': (eval):2: syntax error, unexpected '<' (SyntaxError)
</div>
^
        from </div>
        from ^
        from (eval):2: syntax error, unexpected '<'
        from </div>
        from ^
```

I think, we should ignore such errors and allow source to be not defined.