### PR TITLE
Add csv dependency to gemspec

### DIFF
--- a/trace_location.gemspec
+++ b/trace_location.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.6.0'
 
+  s.add_dependency 'csv'
   s.add_dependency 'method_source'
 
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
When this gem is loaded, warning log is outputted because 'csv' will no longer be part of the default gems starting from Ruby 3.4.0.

Example log:

```
❯ bin/rails middleware
/Users/tnagatomi/.local/share/mise/installs/ruby/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75: warning: /Users/tnagatomi/.local/share/mise/installs/ruby/3.3.5/lib/ruby/3.3.0/csv.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add csv to your Gemfile or gemspec to silence this warning.
```

I added 'csv' dependency to gemspec to fix this.