### PR TITLE
Support ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,21 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     name: ${{ matrix.ruby }}
     strategy:
       matrix:
+        experimental: [false]
         ruby:
           - "2.6"
           - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
+          - "3.3"
+          - "3.4"
+        include:
+          - { ruby: head, experimental: true }
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ jobs:
       matrix:
         experimental: [false]
         ruby:
-          - "2.6"
-          - "2.7"
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 * Bump rexml from 3.2.8 to 3.3.9 (#36)
 * Add csv dependency to gemspec (#35 by @tnagatomi)
 * Support Ruby 3.4
+* Drop Ruby <= 3.0 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 * Use GitHub Actions for CI instead of Travis CI
 * Bump rexml from 3.2.8 to 3.3.9 (#36)
 * Add csv dependency to gemspec (#35 by @tnagatomi)
+* Support Ruby 3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,4 +59,4 @@ DEPENDENCIES
   trace_location!
 
 BUNDLED WITH
-   2.1.4
+   2.6.2

--- a/trace_location.gemspec
+++ b/trace_location.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.bindir        = 'exe'
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 3.1.0'
 
   s.add_dependency 'csv'
   s.add_dependency 'method_source'


### PR DESCRIPTION
This pull request includes updates to the CI configuration, support for newer Ruby versions, and adjustments to gem specifications. The most important changes include updating the Ruby versions supported, modifying the CI workflow, and updating the gemspec file.

Support for newer Ruby versions and dropping old versions:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R9): Added support for Ruby 3.4 and dropped support for Ruby versions <= 3.0.
* [`trace_location.gemspec`](diffhunk://#diff-6bb019e05733c09d0c762e72b239a38e2cc74460a9376e91422c121b5d33b9b7L24-R24): Updated the required Ruby version to be >= 3.1.0.

CI workflow updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR12-R23): Modified the CI workflow to include Ruby versions 3.1, 3.2, 3.3, 3.4, and head, and added an experimental flag to allow certain jobs to continue on error.