### PR TITLE
Fix rubocop offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -58,10 +58,3 @@ Style/Semicolon:
 Style/StderrPuts:
   Exclude:
     - 'lib/trace_location.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiterals:
-  Exclude:
-    - 'lib/trace_location.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,10 +22,6 @@ RSpec/NestedGroups:
   Exclude:
     - 'spec/trace_location_spec.rb'
 
-Security/Eval:
-  Exclude:
-    - 'lib/trace_location/cli.rb'
-
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,12 +17,6 @@ Lint/SuppressedException:
   Exclude:
     - 'lib/trace_location/collector.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AutoCorrect.
-RSpec/HooksBeforeExamples:
-  Exclude:
-    - 'spec/trace_location_spec.rb'
-
 # Configuration parameters: Max, AllowedGroups.
 RSpec/NestedGroups:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -26,16 +26,6 @@ Security/Eval:
   Exclude:
     - 'lib/trace_location/cli.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, AllowedMethods, AllowedPatterns, AllowBracesOnProceduralOneLiners, BracesRequiredMethods.
-# SupportedStyles: line_count_based, semantic, braces_for_chaining, always_braces
-# ProceduralMethods: benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
-# FunctionalMethods: let, let!, subject, watch
-# AllowedMethods: lambda, proc, it
-Style/BlockDelimiters:
-  Exclude:
-    - 'spec/trace_location_spec.rb'
-
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
   Exclude:
@@ -45,11 +35,5 @@ Style/Documentation:
 
 # This cop supports safe autocorrection (--autocorrect).
 Style/EvalWithLocation:
-  Exclude:
-    - 'spec/trace_location_spec.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowAsExpressionSeparator.
-Style/Semicolon:
   Exclude:
     - 'spec/trace_location_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,11 +49,6 @@ Style/EvalWithLocation:
     - 'spec/trace_location_spec.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
-Style/RedundantFreeze:
-  Exclude:
-    - 'lib/trace_location/event.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 Style/RedundantRegexpEscape:
   Exclude:
     - 'lib/trace_location/event.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,12 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AllowSafeAssignment.
-Lint/AssignmentInCondition:
-  Exclude:
-    - 'lib/trace_location/cli.rb'
-
 # Configuration parameters: AllowComments, AllowNil.
 Lint/SuppressedException:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,8 +32,3 @@ Style/Documentation:
     - 'spec/**/*'
     - 'test/**/*'
     - 'lib/trace_location/cli.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-Style/EvalWithLocation:
-  Exclude:
-    - 'spec/trace_location_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,13 +17,6 @@ Lint/SuppressedException:
   Exclude:
     - 'lib/trace_location/collector.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: SkipBlocks, EnforcedStyle, OnlyStaticConstants.
-# SupportedStyles: described_class, explicit
-RSpec/DescribedClass:
-  Exclude:
-    - 'spec/trace_location_spec.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AutoCorrect.
 RSpec/HooksBeforeExamples:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,14 +48,6 @@ Style/EvalWithLocation:
   Exclude:
     - 'spec/trace_location_spec.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, always_true, never
-Style/FrozenStringLiteralComment:
-  Exclude:
-    - 'exe/trace_location'
-    - 'lib/trace_location/cli.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantFreeze:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -65,11 +65,3 @@ Style/StderrPuts:
 Style/StringLiterals:
   Exclude:
     - 'lib/trace_location.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
-# URISchemes: http, https
-Layout/LineLength:
-  Exclude:
-    - 'lib/trace_location/event.rb'
-    - 'trace_location.gemspec'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,13 +17,6 @@ Lint/SuppressedException:
   Exclude:
     - 'lib/trace_location/collector.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: be, be_nil
-RSpec/BeNil:
-  Exclude:
-    - 'spec/trace_location_spec.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: SkipBlocks, EnforcedStyle, OnlyStaticConstants.
 # SupportedStyles: described_class, explicit

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,11 +49,6 @@ Style/EvalWithLocation:
     - 'spec/trace_location_spec.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
-Style/RedundantRegexpEscape:
-  Exclude:
-    - 'lib/trace_location/event.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowAsExpressionSeparator.
 Style/Semicolon:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -53,8 +53,3 @@ Style/EvalWithLocation:
 Style/Semicolon:
   Exclude:
     - 'spec/trace_location_spec.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-Style/StderrPuts:
-  Exclude:
-    - 'lib/trace_location.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix rubocop offenses
+
 ## 1.0.0 (2025-01-01)
 
 * Use GitHub Actions for CI instead of Travis CI

--- a/exe/trace_location
+++ b/exe/trace_location
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'trace_location'
 require 'trace_location/cli'

--- a/lib/trace_location.rb
+++ b/lib/trace_location.rb
@@ -15,7 +15,7 @@ module TraceLocation # :nodoc:
     Report.build(result.events, result.return_value, options).generate
     true
   rescue StandardError => e
-    $stderr.puts "Failure: TraceLocation got an unexpected error."
+    $stderr.puts 'Failure: TraceLocation got an unexpected error.'
     $stderr.puts e.full_message
     false
   end

--- a/lib/trace_location.rb
+++ b/lib/trace_location.rb
@@ -15,8 +15,8 @@ module TraceLocation # :nodoc:
     Report.build(result.events, result.return_value, options).generate
     true
   rescue StandardError => e
-    $stderr.puts 'Failure: TraceLocation got an unexpected error.'
-    $stderr.puts e.full_message
+    warn 'Failure: TraceLocation got an unexpected error.'
+    warn e.full_message
     false
   end
 

--- a/lib/trace_location/cli.rb
+++ b/lib/trace_location/cli.rb
@@ -22,7 +22,7 @@ module TraceLocation
       opt.order!(argv, into: params)
       params.transform_keys! { |k| k.to_s.gsub('-', '_').to_sym }
 
-      if code = params.delete(:e)
+      if (code = params.delete(:e))
         exec_code code, params
       else
         file = argv.shift

--- a/lib/trace_location/cli.rb
+++ b/lib/trace_location/cli.rb
@@ -54,7 +54,7 @@ module TraceLocation
 
     def exec_code(code, params)
       TraceLocation.trace(params) do
-        eval code
+        eval code # rubocop:disable Security/Eval
       end
     end
   end

--- a/lib/trace_location/cli.rb
+++ b/lib/trace_location/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'optparse'
 
 module TraceLocation

--- a/lib/trace_location/event.rb
+++ b/lib/trace_location/event.rb
@@ -2,7 +2,7 @@
 
 module TraceLocation
   class Event # :nodoc:
-    CLASS_FORMAT = /\A#<(?:Class|refinement)\:([A-Za-z0-9\:]+).*>\z/
+    CLASS_FORMAT = /\A#<(?:Class|refinement):([A-Za-z0-9:]+).*>\z/
     attr_reader :id, :event, :path, :lineno, :caller_path, :caller_lineno, :owner, :name, :source, :hierarchy, :is_module
 
     def initialize(id:, event:, path:, lineno:, caller_path:, caller_lineno:, owner:, name:, source:, hierarchy:, is_module:)

--- a/lib/trace_location/event.rb
+++ b/lib/trace_location/event.rb
@@ -2,7 +2,7 @@
 
 module TraceLocation
   class Event # :nodoc:
-    CLASS_FORMAT = /\A#<(?:Class|refinement)\:([A-Za-z0-9\:]+).*>\z/.freeze
+    CLASS_FORMAT = /\A#<(?:Class|refinement)\:([A-Za-z0-9\:]+).*>\z/
     attr_reader :id, :event, :path, :lineno, :caller_path, :caller_lineno, :owner, :name, :source, :hierarchy, :is_module
 
     def initialize(id:, event:, path:, lineno:, caller_path:, caller_lineno:, owner:, name:, source:, hierarchy:, is_module:)

--- a/lib/trace_location/event.rb
+++ b/lib/trace_location/event.rb
@@ -3,9 +3,11 @@
 module TraceLocation
   class Event # :nodoc:
     CLASS_FORMAT = /\A#<(?:Class|refinement):([A-Za-z0-9:]+).*>\z/
-    attr_reader :id, :event, :path, :lineno, :caller_path, :caller_lineno, :owner, :name, :source, :hierarchy, :is_module
+    attr_reader :id, :event, :path, :lineno, :caller_path, :caller_lineno, :owner, :name, :source, :hierarchy,
+                :is_module
 
-    def initialize(id:, event:, path:, lineno:, caller_path:, caller_lineno:, owner:, name:, source:, hierarchy:, is_module:)
+    def initialize(id:, event:, path:, lineno:, caller_path:, caller_lineno:, owner:, name:, source:, hierarchy:,
+                   is_module:)
       @id = id
       @event = event
       @path = path

--- a/spec/trace_location_spec.rb
+++ b/spec/trace_location_spec.rb
@@ -385,22 +385,34 @@ RSpec.describe TraceLocation do
       end
     end
 
-    it 'passing a block including the `pp` method' do
-      expect {
-        described_class.trace { pp 'foo' }
-      }.to output(/foo/).to_stdout
-    end
+    describe 'passing a block' do
+      context 'with including the `puts` method' do
+        let(:block) { -> { pp 'foo' } }
 
-    it 'passing a block incluing GC module method' do
-      expect {
-        described_class.trace { GC.stat; puts 'success' }
-      }.to output(/success/).to_stdout
-    end
+        it { expect { described_class.trace(&block) }.to output(/foo/).to_stdout }
+      end
 
-    it 'passing a block incluing eval' do
-      expect {
-        described_class.trace { eval 'def foo() pp "foo" end'; foo }
-      }.to output(/foo/).to_stdout
+      context 'with including GC module method' do
+        let(:block) do
+          lambda do
+            GC.stat
+            puts 'success'
+          end
+        end
+
+        it { expect { described_class.trace(&block) }.to output(/success/).to_stdout }
+      end
+
+      context 'with including `eval` method' do
+        let(:block) do
+          lambda do
+            eval 'def foo() pp "foo" end'
+            foo
+          end
+        end
+
+        it { expect { described_class.trace(&block) }.to output(/foo/).to_stdout }
+      end
     end
   end
 end

--- a/spec/trace_location_spec.rb
+++ b/spec/trace_location_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TraceLocation do
 
   describe '.trace' do
     before do
-      TraceLocation.config.dest_dir = 'spec/support/logs'
+      described_class.config.dest_dir = 'spec/support/logs'
     end
 
     context 'when the method is called not depending on other class' do
@@ -20,7 +20,7 @@ RSpec.describe TraceLocation do
       let(:method) { Independence.method(:independent_method) }
 
       before do
-        TraceLocation.trace { method.call }
+        described_class.trace { method.call }
       end
 
       it 'including correct path' do
@@ -44,7 +44,7 @@ RSpec.describe TraceLocation do
       let(:depended_method) { Independence.method(:independent_method) }
 
       before do
-        TraceLocation.trace { method.call }
+        described_class.trace { method.call }
       end
 
       it 'including path of target method' do
@@ -84,7 +84,7 @@ RSpec.describe TraceLocation do
         let(:depended_method) { Independence.method(:independent_method) }
 
         before do
-          TraceLocation.trace(match: [:dependence_on_other_class, 'dependence_on_multiple_class']) { method.call }
+          described_class.trace(match: [:dependence_on_other_class, 'dependence_on_multiple_class']) { method.call }
         end
 
         it 'including path of target method' do
@@ -132,7 +132,7 @@ RSpec.describe TraceLocation do
         let(:depended_method) { Independence.method(:independent_method) }
 
         before do
-          TraceLocation.trace(match: /dependence_on_other_class/) { method.call }
+          described_class.trace(match: /dependence_on_other_class/) { method.call }
         end
 
         it 'including path of target method' do
@@ -172,7 +172,7 @@ RSpec.describe TraceLocation do
         let(:depended_method) { Independence.method(:independent_method) }
 
         before do
-          TraceLocation.trace(methods: [:dependent_method]) { method.call }
+          described_class.trace(methods: [:dependent_method]) { method.call }
         end
 
         it 'including path of target method' do
@@ -201,7 +201,7 @@ RSpec.describe TraceLocation do
         let(:depended_method) { Independence.method(:independent_method) }
 
         before do
-          TraceLocation.trace(ignore: [:dependence_on_other_class, 'dependence_on_multiple_class']) { method.call }
+          described_class.trace(ignore: [:dependence_on_other_class, 'dependence_on_multiple_class']) { method.call }
         end
 
         it 'excluding path of called method' do
@@ -249,7 +249,7 @@ RSpec.describe TraceLocation do
         let(:depended_method) { Independence.method(:independent_method) }
 
         before do
-          TraceLocation.trace(ignore: /dependence_on_other_class/) { method.call }
+          described_class.trace(ignore: /dependence_on_other_class/) { method.call }
         end
 
         it 'excluding path of target method' do
@@ -287,7 +287,7 @@ RSpec.describe TraceLocation do
         let(:method) { Independence.method(:independent_method) }
 
         before do
-          TraceLocation.trace(format: :markdown) { method.call }
+          described_class.trace(format: :markdown) { method.call }
         end
 
         it 'including correct path' do
@@ -310,7 +310,7 @@ RSpec.describe TraceLocation do
         let(:method) { Independence.method(:independent_method) }
 
         before do
-          TraceLocation.trace(format: :md) { method.call }
+          described_class.trace(format: :md) { method.call }
         end
 
         it 'including correct path' do
@@ -333,7 +333,7 @@ RSpec.describe TraceLocation do
         let(:method) { Independence.method(:independent_method) }
 
         before do
-          TraceLocation.trace(format: :log) { method.call }
+          described_class.trace(format: :log) { method.call }
         end
 
         it 'including path of target method' do
@@ -357,7 +357,7 @@ RSpec.describe TraceLocation do
         let(:method) { Independence.method(:independent_method) }
 
         before do
-          TraceLocation.trace(format: :csv) { method.call }
+          described_class.trace(format: :csv) { method.call }
         end
 
         it 'including header' do
@@ -381,19 +381,19 @@ RSpec.describe TraceLocation do
 
     it 'passing a block including the `pp` method' do
       expect {
-        TraceLocation.trace { pp 'foo' }
+        described_class.trace { pp 'foo' }
       }.to output(/foo/).to_stdout
     end
 
     it 'passing a block incluing GC module method' do
       expect {
-        TraceLocation.trace { GC.stat; puts 'success' }
+        described_class.trace { GC.stat; puts 'success' }
       }.to output(/success/).to_stdout
     end
 
     it 'passing a block incluing eval' do
       expect {
-        TraceLocation.trace { eval 'def foo() pp "foo" end'; foo }
+        described_class.trace { eval 'def foo() pp "foo" end'; foo }
       }.to output(/foo/).to_stdout
     end
 

--- a/spec/trace_location_spec.rb
+++ b/spec/trace_location_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe TraceLocation do
       described_class.config.dest_dir = 'spec/support/logs'
     end
 
+    after do
+      Dir.foreach('spec/support/logs') do |file_name|
+        FileUtils.rm File.join('spec', 'support', 'logs', file_name), force: true
+      end
+    end
+
     context 'when the method is called not depending on other class' do
       let(:log_file) { Dir.entries('spec/support/logs/').select { |file_name| file_name.match?(/\.md/) }.last }
       let(:content) { File.read File.join('spec', 'support', 'logs', log_file) }
@@ -395,12 +401,6 @@ RSpec.describe TraceLocation do
       expect {
         described_class.trace { eval 'def foo() pp "foo" end'; foo }
       }.to output(/foo/).to_stdout
-    end
-
-    after do
-      Dir.foreach('spec/support/logs') do |file_name|
-        FileUtils.rm File.join('spec', 'support', 'logs', file_name), force: true
-      end
     end
   end
 end

--- a/spec/trace_location_spec.rb
+++ b/spec/trace_location_spec.rb
@@ -6,7 +6,7 @@ require_relative 'support/dummy/dependence_on_multiple_class'
 
 RSpec.describe TraceLocation do
   it 'has a version number' do
-    expect(TraceLocation::VERSION).not_to be nil
+    expect(TraceLocation::VERSION).not_to be_nil
   end
 
   describe '.trace' do

--- a/spec/trace_location_spec.rb
+++ b/spec/trace_location_spec.rb
@@ -406,7 +406,7 @@ RSpec.describe TraceLocation do
       context 'with including `eval` method' do
         let(:block) do
           lambda do
-            eval 'def foo() pp "foo" end'
+            eval 'def foo() pp "foo" end', binding, __FILE__, __LINE__
             foo
           end
         end

--- a/trace_location.gemspec
+++ b/trace_location.gemspec
@@ -11,7 +11,10 @@ Gem::Specification.new do |s|
   s.email         = ['yhirano@me.com']
   s.homepage      = 'https://github.com/yhirano55/trace_location'
   s.summary       = 'helps you get tracing the source location of codes'
-  s.description   = %(TraceLocation helps you get tracing the source location of codes, and helps you can get reading the huge open souce libraries in Ruby)
+  s.description   = <<~DESCRIPTION
+    TraceLocation helps you get tracing the source location of codes,
+    and helps you can get reading the huge open souce libraries in Ruby
+  DESCRIPTION
   s.license       = 'MIT'
   s.files         = Dir.chdir(File.expand_path('.', __dir__)) do
     `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
This pull request includes various changes to improve code quality, fix RuboCop offenses, and enhance the `trace_location` gem. The most important changes include updating the RuboCop configuration, modifying error handling, and improving test descriptions and structure.

### RuboCop Configuration Updates:
* Removed exclusions for several RuboCop cops in the `.rubocop_todo.yml` file. This change ensures that the codebase adheres to more stringent linting rules.

### Code Quality Improvements:
* Added `# frozen_string_literal: true` to several files to optimize string handling and improve performance. [[1]](diffhunk://#diff-bb074c5a0c67b3a88c6bcef9d276cd5411d434d48f1f60f4d5bdbf71a19fdc22R2) [[2]](diffhunk://#diff-d7cc113f99b3d76f460b8af62841b23d423b735c60f6e04866ba34408cdb8a93R1-R2)
* Replaced `$stderr.puts` with `warn` for better error handling and consistency in `lib/trace_location.rb`.
* Updated `eval` usage to include a RuboCop directive to disable the security warning in `lib/trace_location/cli.rb`.

### Testing Enhancements:
* Improved test descriptions and structure in `spec/trace_location_spec.rb` by using `described_class` and adding context blocks for better readability and maintainability. [[1]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL9-R20) [[2]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL23-R29) [[3]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL47-R53) [[4]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL87-R93) [[5]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL135-R141) [[6]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL175-R181) [[7]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL204-R210) [[8]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL252-R258) [[9]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL290-R296) [[10]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL313-R319) [[11]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL336-R342) [[12]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL360-R366) [[13]](diffhunk://#diff-4635bc2b73abecda78fb8b08d3072c0a1d43feaf55912f59ac3e000ff31ac0bfL382-R414)

### Documentation and Changelog:
* Updated the `CHANGELOG.md` to include a note about fixing RuboCop offenses.
* Improved the gem description formatting in `trace_location.gemspec` for better readability.

These changes collectively enhance the code quality, maintainability, and performance of the `trace_location` gem.