### PR TITLE
Add warning gem to development dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           - "3.4"
         include:
           - { ruby: head, experimental: true }
+    env:
+      RUBYOPT: "-W:deprecated"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix rubocop offenses
+* Add warning gem to development dependencies
 
 ## 1.1.0 (2025-01-02)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
     unicode-display_width (3.1.3)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    warning (1.5.0)
 
 PLATFORMS
   ruby
@@ -67,6 +68,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   trace_location!
+  warning
 
 BUNDLED WITH
    2.6.2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,9 @@
 require 'bundler/setup'
 require 'trace_location'
 require 'fileutils'
+require 'warning'
+
+Warning.process { :raise }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/trace_location.gemspec
+++ b/trace_location.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'warning'
 end


### PR DESCRIPTION
This pull request includes changes to improve the handling of warnings and deprecations in the project. The most important changes include setting an environment variable for Ruby options, adding a new dependency for handling warnings, and configuring the warning processing behavior in the test suite.

Enhancements to warnings and deprecations handling:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR24-R25): Added the `RUBYOPT` environment variable to enable deprecation warnings.
* [`spec/spec_helper.rb`](diffhunk://#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94R6-R8): Added the `warning` gem and configured it to raise exceptions on warnings.
* [`trace_location.gemspec`](diffhunk://#diff-6bb019e05733c09d0c762e72b239a38e2cc74460a9376e91422c121b5d33b9b7R35): Added `warning` as a development dependency.